### PR TITLE
bug fix: when resampling, must scale displacements

### DIFF
--- a/challenge_eval/evaluation.py
+++ b/challenge_eval/evaluation.py
@@ -69,6 +69,8 @@ def evaluate_ExM(INPUT_PATH,GT_PATH,JSON_PATH,OUTPUT_PATH,SAMPLING_FACTOR, verbo
             fixed_seg = ndimage.zoom(fixed_seg, SAMPLING_FACTOR, order= 0)
             moving_seg = ndimage.zoom(moving_seg, SAMPLING_FACTOR, order= 0)
             disp_field = ndimage.zoom(disp_field, (SAMPLING_FACTOR,SAMPLING_FACTOR,SAMPLING_FACTOR,1), order= 1)
+            # BUG FIX, GREG FLEISHMAN
+            disp_field *= SAMPLING_FACTOR
 
         D,H,W = fixed_seg.shape
         identity = np.meshgrid(np.arange(D), np.arange(H), np.arange(W), indexing='ij')


### PR DESCRIPTION
The evaluation script takes a --sampling_factor argument which is passed to zoom to rescale the inputs. If the displacement vector field is resampled, it must also be scaled by the sampling_factor. Consider a displacement vector of [1, 1, 1] before resampling. This means move one voxel along each axis. Now consider resampling the data with a sampling_factor of 0.5. All voxels are now twice as big. Using the original value of [1, 1, 1] is now *double* the amount of displacement it was before resampling. So, what you really want is [0.5, 0.5, 0.5], which is: `disp_field *= SAMPLING_FACTOR` which I have added to line 73 of evaluation.py.