### PR TITLE
fix naming error

### DIFF
--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -44,4 +44,4 @@ export PYTHONPATH=$(pwd)
 
 ```
 
-4. Launch Jupyter notebooks by running `jupyter notebook`. Open the .ipynb file called 'tutorial'. 
+4. Launch Jupyter notebooks by running `jupyter notebook`. Open the .ipynb file called 'baseline_tutorial'. 


### PR DESCRIPTION
The tutorial ipynb name is baseline_tutorial.ipynb not tutorial