### PR TITLE
Optimized Memory Usage

### DIFF
--- a/challenge_eval/README.md
+++ b/challenge_eval/README.md
@@ -38,7 +38,7 @@ Note: The `evaluation_configs` directory contains evaluation configuration files
 - Example to evaluate zebrafish alignment, Run:
 
 ```
-python evlatiation.py \
+python evaluation.py \
 --input /insert_working_directory/submission/ \
 --data /insert_working_directory/dataset/ \
 --output /insert_working_directory/results/ \

--- a/challenge_eval/evaluation_configs/c_elegan_TEST_evaluation_config.json
+++ b/challenge_eval/evaluation_configs/c_elegan_TEST_evaluation_config.json
@@ -1,0 +1,30 @@
+{
+    "task_name": "c_elegan",
+    "dataset":"test",
+    "eval_config_version": 0.1,
+    "evaluation_methods": [
+        {
+            "name": "LogJacDetStd",
+            "metric": "sdlogj"
+        },
+        {
+            "name": "DSC",
+            "metric": "dice"
+        },
+        {
+            "name": "HD95",
+            "metric": "hd95"
+        }
+    ],
+    "expected_shape": [
+        580,
+        2048,
+        2048,
+        3
+    ],
+    "eval_pairs": [
+        "pair5",
+        "pair6",
+        "pair7"
+    ]
+}

--- a/challenge_eval/evaluation_configs/mouse_TEST_evaluation_config.json
+++ b/challenge_eval/evaluation_configs/mouse_TEST_evaluation_config.json
@@ -1,0 +1,30 @@
+{
+    "task_name": "mouse",
+    "dataset":"test",
+    "eval_config_version": 0.1,
+    "evaluation_methods": [
+        {
+            "name": "LogJacDetStd",
+            "metric": "sdlogj"
+        },
+        {
+            "name": "DSC",
+            "metric": "dice"
+        },
+        {
+            "name": "HD95",
+            "metric": "hd95"
+        }
+    ],
+    "expected_shape": [
+        81,
+        2048,
+        2048,
+        3
+    ],
+    "eval_pairs": [
+        "pair5",
+        "pair6",
+        "pair7"
+    ]
+}

--- a/challenge_eval/evaluation_configs/zebrafish_TEST_evaluation_config.json
+++ b/challenge_eval/evaluation_configs/zebrafish_TEST_evaluation_config.json
@@ -1,0 +1,30 @@
+{
+    "task_name": "zebrafish",
+    "dataset":"test",
+    "eval_config_version": 0.1,
+    "evaluation_methods": [
+        {
+            "name": "LogJacDetStd",
+            "metric": "sdlogj"
+        },
+        {
+            "name": "DSC",
+            "metric": "dice"
+        },
+        {
+            "name": "HD95",
+            "metric": "hd95"
+        }
+    ],
+    "expected_shape": [
+        133,
+        2048,
+        2048,
+        3
+    ],
+    "eval_pairs": [
+        "pair5",
+        "pair6",
+        "pair7"
+    ]
+}


### PR DESCRIPTION
##  Memory usage optimization during evaluation:
 
### To test:
- Make sure your fixed and moving volumes are already downsampled by a factor of 0.5.
- Add `--optimize` arg while running the `evaluation.py`.
- Remove `LogJacDetStd` from the evaluation methods of the task configuration .json file. 
```
python evaluation.py \
--input /insert_working_directory/submission/ \
--data /insert_working_directory/dataset/ \
--output /insert_working_directory/results/ \
--config /insert_working_directory/evaluation_configs/zebrafish_VAL_evaluation_config.json \
--sampling_factor 0.5 \
--optimize 
```
 